### PR TITLE
Fix colour and screen Glitches in Twinworld

### DIFF
--- a/rtl/memc.v
+++ b/rtl/memc.v
@@ -420,7 +420,7 @@ wire   cpu_mem_we    = cpu_we & ((phycs & spvmd) | (table_valid & logcs)) & ~rom
 
 assign tablew        = cpu_load & cpu_cyc & cpu_we & spvmd & (cpu_address[25:23] == 3'b111) & (cpu_address[12] == 0) & (cpu_address[7] == 0); // &3800000+ 
 wire   memw          = cpu_load & cpu_cyc & cpu_we & spvmd & (cpu_address[25:21] == 5'b11011); // &3600000
-assign vidw          = cpu_load & cpu_cyc & cpu_we & vidc_cs; // &3400000
+assign vidw          = cpu_cyc  & cpu_we & vidc_cs; // &3400000
 
 // bus chip selects
 wire   logcs         = cpu_address[25] == 1'b0;                                                        // 0000000 - 1FFFFFF


### PR DESCRIPTION
Looking at a disassembly of twinworld I could see that it's using STMIA instructions to write screen setup and palette data to the VIDC. Extracting this code into a small test program replicates the bug, but separating the VIDC writes into single register STMs gave the expected result.

cpu_load seems to only be true for the first write of a STM instruction, so subsequent writes to the VIDC registers were being lost. 

This should fix the Twinworld issues in issue #9, but the James Pond glitches have a different cause